### PR TITLE
feat: Support for transforming Markdown headings into JSX object format

### DIFF
--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -1,6 +1,7 @@
+import type { ArrayOrNot } from "@/types/utility";
+import React from "react";
 import clsx from "clsx";
 import { MDXRemoteProps } from "next-mdx-remote/rsc";
-import React from "react";
 import { gunzipSync } from "zlib";
 import { strToSlug } from "@/lib/utils/string";
 import { Post } from "@/const/definitions";
@@ -43,8 +44,9 @@ export const createMDXHeadings = () => {
     MDXRemoteProps["components"]
   >((acc, _, idx) => {
     const tagName = `h${idx + 1}`;
-    const createHeading = (props: DetailedHTMLProps<HTMLHeadingElement>) => {
-      const id = strToSlug(props.children as string).toLowerCase();
+    const createHeading = (props: { children: string | JSX.Element }) => {
+      const str = handleHeadingStr(props);
+      const id = strToSlug(str).toLowerCase();
       return convertToMDX(tagName as "h1", id)(props);
     };
     return {
@@ -54,6 +56,22 @@ export const createMDXHeadings = () => {
   }, {});
 
   return headings;
+};
+
+export type HandleHeadingStrProps = {
+  children: ArrayOrNot<string | { props: HandleHeadingStrProps }>;
+};
+export const handleHeadingStr = ({ children }: HandleHeadingStrProps) => {
+  let ret = "";
+  if (typeof children === "string") ret = children;
+  else if (Array.isArray(children)) {
+    for (const child of children) {
+      ret += handleHeadingStr({ children: child });
+    }
+  } else if (typeof children === "object" && children.props) {
+    ret = handleHeadingStr(children.props);
+  }
+  return ret;
 };
 
 export const format = (date: Date) => {

--- a/src/types/utility.d.ts
+++ b/src/types/utility.d.ts
@@ -1,0 +1,1 @@
+export type ArrayOrNot<T> = T | T[];

--- a/test/utils/markdown.test.ts
+++ b/test/utils/markdown.test.ts
@@ -1,0 +1,67 @@
+import { describe, test, expect } from "bun:test";
+import { handleHeadingStr } from "@/lib/utils/markdown";
+
+describe("handleHeadingStr", () => {
+  test("string headings", () => {
+    const headings = { children: "str" };
+
+    const actual = handleHeadingStr(headings);
+    const expected = "str";
+
+    expect(actual).toBe(expected);
+  });
+
+  test("string array heading", () => {
+    const headings = { children: ["string", "array"] };
+
+    const actual = handleHeadingStr(headings);
+    const expected = "stringarray";
+
+    expect(actual).toBe(expected);
+  });
+
+  test("object heading", () => {
+    const headings = {
+      children: {
+        $$typeof: Symbol("react.element"),
+        type: "[Function: a]",
+        key: null,
+        ref: null,
+        props: {
+          href: "href",
+          children: "Scheduler",
+        },
+        _owner: null,
+        _store: {},
+      },
+    };
+
+    const actual = handleHeadingStr(headings);
+    const expected = "Scheduler";
+
+    expect(actual).toBe(expected);
+  });
+
+  test("complex array heading", () => {
+    const headings = {
+      children: [
+        "1. vue, angular는 ",
+        {
+          $$typeof: "Symbol(react.element)",
+          type: "code",
+          key: null,
+          ref: null,
+          props: { children: "프레임워크" },
+          _owner: null,
+          _store: {},
+        },
+        "다.",
+      ],
+    };
+
+    const actual = handleHeadingStr(headings);
+    const expected = "1. vue, angular는 프레임워크다.";
+
+    expect(actual).toBe(expected);
+  });
+});


### PR DESCRIPTION
The `next-remote-mdx` library automatically transforms Markdown headings, which need to be converted into JSX markup, into appropriate forms.

The expected output can be a `string`, `JSX.Element`, or an array of `string` or `JSX.Element`.

A recursive abstract type and string conversion algorithm have been implemented to handle this.